### PR TITLE
Updates

### DIFF
--- a/src/components/AddServerModal/AddServerModal.tsx
+++ b/src/components/AddServerModal/AddServerModal.tsx
@@ -35,7 +35,7 @@ const AddServerModal: React.FC<IProps> = props => {
       return;
     }
 
-    if (servers.find(server => server.url === serverURL)) {
+    if (servers?.find(server => server.url === serverURL)) {
       setErrorMessage('Server already exists!');
       return;
     }

--- a/src/components/KuskExtensions/KuskExtensionsPanelContent.tsx
+++ b/src/components/KuskExtensions/KuskExtensionsPanelContent.tsx
@@ -20,7 +20,7 @@ const createExtensionTreeNode = (key: string, children: any): DataNode => {
   let title: JSX.Element = (
     <div>
       {key}
-      {propertyValue && (
+      {propertyValue?.toString() && (
         <>
           : <S.ExtensionValueLabel $type={typeof children}>{propertyValue.toString()}</S.ExtensionValueLabel>
         </>

--- a/src/components/RawApiSpec/styled.tsx
+++ b/src/components/RawApiSpec/styled.tsx
@@ -8,4 +8,10 @@ export const ErrorLabel = styled.span`
 
 export const RawApiSpecContainer = styled.div`
   ${SwaggerUIStyle}
+
+  & .swagger-ui {
+    & .scheme-container {
+      display: none;
+    }
+  }
 `;

--- a/src/components/TableOfContents/TableOfContentsLabel.tsx
+++ b/src/components/TableOfContents/TableOfContentsLabel.tsx
@@ -24,6 +24,7 @@ const TableOfContentsLabel: React.FC<IProps> = props => {
   const {deprecated = false, kuskExtensionRef = '', operation = '', tag = ''} = props;
 
   const dispatch = useAppDispatch();
+  const apiInfoActiveTab = useAppSelector(state => state.ui.apiInfoActiveTab);
   const kuskExtensionsActiveKeys = useAppSelector(state => state.ui.kuskExtensionsActiveKeys[level]);
 
   const onTagClickHandler = useCallback(
@@ -69,7 +70,7 @@ const TableOfContentsLabel: React.FC<IProps> = props => {
         </S.LabelMethodTag>
       )}
 
-      {Boolean(kuskExtensionRef) && (
+      {Boolean(kuskExtensionRef) && apiInfoActiveTab === 'raw-api-spec' && (
         <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={KuskExtensionTooltip}>
           <S.ApiOutlined onClick={onKuskExtensionIconClickHandler} />
         </Tooltip>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,7 @@ ReactDOM.render(
     <Provider store={store}>
       <BrowserRouter>
         <GlobalStyle />
-        <RestfulProvider base="kgwtest.kusk-system.svc.cluster.local:8080/">
+        <RestfulProvider base="/api/">
           <App />
         </RestfulProvider>
       </BrowserRouter>

--- a/src/swaggerUI/plugins/DynamicServersPlugin/DynamicServersPlugin.tsx
+++ b/src/swaggerUI/plugins/DynamicServersPlugin/DynamicServersPlugin.tsx
@@ -10,7 +10,12 @@ const DynamicServersPlugin = () => ({
       const specJson = spec().toJS().json;
 
       const updateSpecServers = (url: string) => {
-        specJson.servers.push({url, description: ''});
+        if (specJson.servers) {
+          specJson.servers.push({url, description: ''});
+        } else {
+          specJson['servers'] = [{url, description: ''}];
+        }
+
         specActions.updateJsonSpec(specJson);
         oas3Actions.setSelectedServer(url);
       };


### PR DESCRIPTION
## Changes

- Hide kusk-extensions icon from the table of contents for Post-Processed API Spec

## Fixes

- Show the `Add server` action button the `servers` property is missing from the spec
- Hide servers/schemes component for the Raw API Spec
- Show disabled property value for top-level extension

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
