### PR TITLE
Sidebar UI tweaks

### DIFF
--- a/src/components/Sidebar/DashboardMenu.styled.tsx
+++ b/src/components/Sidebar/DashboardMenu.styled.tsx
@@ -8,12 +8,12 @@ export const DashboardMenuContainer = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  border: 1px solid ${Colors.grey4};
+  border-bottom: 1px solid ${Colors.grey4};
 `;
 
 export const Icon = styled(AntdIcon)<{$active: boolean; $border?: boolean}>`
   ${({$active, $border}) => `
-    color: ${$active ? Colors.whitePure : Colors.grey0}};
+    color: ${$active ? Colors.whitePure : Colors.grey1}};
     border-bottom: ${$border ? `1px solid ${Colors.grey4}` : ''};
 `};
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -16,13 +16,13 @@ const Sidebar = () => {
       <DashboardMenu />
 
       <S.OptionsContainer>
-        <S.IconContainer $border>
+        <S.IconContainer>
           <Link to="/settings">
             <S.SettingsFilled />
           </Link>
         </S.IconContainer>
-
-        <S.IconContainer $border>
+        
+        <S.IconContainer>
           <a href="https://github.com/kubeshop/kusk-gateway" target="_blank" rel="noopener noreferrer">
             <S.GithubFilled />
           </a>

--- a/src/components/Sidebar/styled.tsx
+++ b/src/components/Sidebar/styled.tsx
@@ -11,41 +11,45 @@ import {SIDEBAR_WIDTH} from '@constants/constants';
 import Colors from '@styles/colors';
 
 export const Logo = styled.img`
-  height: 50px;
+  height: 36px;
   cursor: pointer;
 `;
 
 export const GithubFilled = styled(RawGithubFilled)`
   color: ${Colors.whitePure};
-  font-size: 24px;
+  font-size: 18px;
   cursor: pointer;
 `;
 
-export const IconContainer = styled.div<{$border?: boolean}>`
+export const IconContainer = styled.div`
   display: flex;
   justify-content: center;
-  padding: 19px 0;
+  padding: 8px 0;
+  opacity: 0.5;
+  transition: all 0.2s ease-in;
 
-  ${({$border}) => `border-bottom: ${$border ? `1px solid ${Colors.grey4}` : ''}`}
+  &:hover {
+    opacity: 1;
+  }
 `;
 
 export const OptionsContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  border: 1px solid ${Colors.grey4};
   margin-top: auto;
+  padding-bottom: 16px;
 `;
 
 export const QuestionCircleFilled = styled(RawQuestionsCircleFilled)`
   color: ${Colors.whitePure};
-  font-size: 24px;
+  font-size: 18px;
   cursor: pointer;
 `;
 
 export const SettingsFilled = styled(RawSettingFilled)`
   color: ${Colors.whitePure};
-  font-size: 24px;
+  font-size: 18px;
   cursor: pointer;
 `;
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,4 +1,4 @@
 export const DASHBOARD_PANE_MIN_WIDTH = 460;
 export const SIDEBAR_WIDTH = 80;
 export const SUPPORTED_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
-export const TOOLTIP_DELAY = 0.5;
+export const TOOLTIP_DELAY = 0.1;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -11,7 +11,7 @@ enum Colors {
 
   cyan2 = '#9AF2EC',
   cyan1 = '#5CDBD3',
-  cyan0 = '#32BAB5',
+  cyan0 = '#135452',
 
   magenta2 = '#CB2B83',
   magenta1 = '#551C3B',


### PR DESCRIPTION
This PR...

## Changes

Just some minor UI tweaks to the sidebar to tidy it up visually :) 
We'll still need to refactor some of the reused components going forward

## Fixes

* Adapted the cyan background color
* Changed the tooltip_delay 

## Before
<img width="1285" alt="Screenshot 2022-04-05 at 20 49 08" src="https://user-images.githubusercontent.com/132332/161838781-e8517726-4569-44e6-8476-124d55f8d9d5.png">

## After
<img width="1329" alt="Screenshot 2022-04-05 at 21 29 07" src="https://user-images.githubusercontent.com/132332/161838794-425e9734-fc2b-40b9-bcac-023119ac2889.png">

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
