### PR TITLE
Adding Design Resources

### DIFF
--- a/.design/README.md
+++ b/.design/README.md
@@ -1,0 +1,55 @@
+# Kusk Gateway Dashboard Design Resources
+
+We'd like to open up our design process to the broader community and are eager to welcome contributors. Since we're currently still shaping this process we didn't want to withhold any progress.
+
+In the mean time feel free to explore this document and the linked resources.
+
+# Table of contents
+
+- [Kusk Gateway Dashboard Design Resources](#kusk-gateway-dashboard-design-resources)
+- [Table of contents](#table-of-contents)
+- [Journeys, Diagrams, Flows](#journeys-diagrams-flows)
+- [Design Tokens](#design-tokens)
+- [Design Components](#design-components)
+- [Icons](#icons)
+- [Views](#views)
+  - [Dashboard](#dashboard)
+- [Contribute](#contribute)
+- [License](#license)
+
+# Journeys, Diagrams, Flows
+
+Tbd...
+
+# Design Tokens
+
+Design Tokens can be extracted from the corresponding [Figma File](https://www.figma.com/file/wecNPLnwPgaQiZaXDWolSa/?node-id=201%3A2110). We're aiming to centralise our design tokens going forward.
+
+# Design Components
+
+Kusk Gateway Dashboard related components can be found in this [Figma File](https://www.figma.com/file/wecNPLnwPgaQiZaXDWolSa/?node-id=201%3A2110)
+
+# Icons
+
+Icons can be found in the following [Figma File](https://www.figma.com/file/wecNPLnwPgaQiZaXDWolSa/?node-id=201%3A2187). We're aiming to centralise the iconset going forward.
+
+# Views
+
+## Dashboard
+
+[Figma Design](https://www.figma.com/file/wecNPLnwPgaQiZaXDWolSa/?node-id=74%3A1672)
+
+# Contribute
+
+- Check out our [Contributor Guide](https://github.com/kubeshop/.github/blob/main/CONTRIBUTING.md) and
+  [Code of Conduct](https://github.com/kubeshop/.github/blob/main/CODE_OF_CONDUCT.md)
+- Clone the public Figma files 
+- Check out open [issues](https://github.com/kubeshop/kusk-gateway/issues) here on GitHub
+- Get in touch with the team by starting a discussion on [GitHub](https://github.com/kubeshop/kusk-gateway/discussions) or on our [Discord Server](https://discord.gg/uNuhy6GDyn).
+- or open an issue of your own that you would like to contribute to the project and use the `ux` tag for it.
+
+# License
+
+[(Back to top)](#table-of-contents)
+
+[MIT](https://mit-license.org/)


### PR DESCRIPTION
This PR...

## Changes

1. I'd like to refer to design relevant files right here in the repo to enable others to contribute also on ux related topics and get a wider insight into this project's setup. 

2. The good thing – people working on this project will also always have a reference to the design files. 

3. Last but not least – I managed to mock a rough Figma version (with some minor improvements) of the current state and separated it into reusable components, design tokens (especially colors) and icons :)

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
