### PR TITLE
feat: add warning icon if step not applicable

### DIFF
--- a/src/components/ApiPublishModal/ApiPublishModal.tsx
+++ b/src/components/ApiPublishModal/ApiPublishModal.tsx
@@ -14,6 +14,8 @@ import {closeApiPublishModal} from '@redux/reducers/ui';
 
 import {ErrorLabel} from '@components/AntdCustom';
 
+import StepTitle from './StepTitle';
+
 import * as S from './styled';
 
 const ApiInfo = lazy(() => import('./ApiInfo'));
@@ -107,14 +109,6 @@ const ApiPublishModal: React.FC = () => {
         }
 
         newApiContent = {name, namespace, openapi: parsedOpenApi};
-
-        if (!deploy) {
-          if (mocking?.enabled) {
-            setIsApiMocked(true);
-          } else if (isApiMocked) {
-            setIsApiMocked(false);
-          }
-        }
       }
 
       if (apiContent) {
@@ -317,15 +311,15 @@ const ApiPublishModal: React.FC = () => {
       <S.Container>
         <S.StepsContainer>
           <Steps direction="vertical" current={activeStepIndex}>
-            <S.Step title="OpenAPI Spec" />
-            <S.Step title="API Info" />
-            <S.Step title="Validation" />
-            <S.Step title="Upstream | Redirect" />
-            <S.Step title="Hosts" />
-            <S.Step title="QOS" />
-            <S.Step title="Path" />
-            <S.Step title="CORS" />
-            <S.Step title="Websocket" />
+            <S.Step title={<StepTitle title="OpenAPI Spec" />} />
+            <S.Step title={<StepTitle title="API Info" />} />
+            <S.Step title={<StepTitle title="Validation" isStepApplicable={!isApiMocked} />} />
+            <S.Step title={<StepTitle title="Upstream | Redirect" isStepApplicable={!isApiMocked} />} />
+            <S.Step title={<StepTitle title="Hosts" />} />
+            <S.Step title={<StepTitle title="QOS" isStepApplicable={!isApiMocked} />} />
+            <S.Step title={<StepTitle title="Path" />} />
+            <S.Step title={<StepTitle title="CORS" />} />
+            <S.Step title={<StepTitle title="Websocket" isStepApplicable={!isApiMocked} />} />
           </Steps>
         </S.StepsContainer>
 
@@ -341,7 +335,9 @@ const ApiPublishModal: React.FC = () => {
             }}
           >
             <Suspense fallback={<Skeleton />}>
-              {activeStep === 'openApiSpec' && <OpenApiSpec form={form} />}
+              {activeStep === 'openApiSpec' && (
+                <OpenApiSpec form={form} setIsApiMocked={value => setIsApiMocked(value)} />
+              )}
               {activeStep === 'apiInfo' && <ApiInfo form={form} />}
               {activeStep === 'validation' && <Validation form={form} isApiMocked={isApiMocked} />}
               {activeStep === 'upstreamOrRedirect' && (

--- a/src/components/ApiPublishModal/OpenApiSpec.tsx
+++ b/src/components/ApiPublishModal/OpenApiSpec.tsx
@@ -10,10 +10,11 @@ import * as S from './OpenApiSpec.styled';
 
 interface IProps {
   form: FormInstance<any>;
+  setIsApiMocked: (value: boolean) => void;
 }
 
 const OpenApiSpec: React.FC<IProps> = props => {
-  const {form} = props;
+  const {form, setIsApiMocked} = props;
 
   const apiContent = useAppSelector(state => state.main.newApiContent);
 
@@ -60,7 +61,7 @@ const OpenApiSpec: React.FC<IProps> = props => {
       </Form.Item>
 
       <Form.Item name={['mocking', 'enabled']} valuePropName="checked">
-        <Checkbox>Enable mocking</Checkbox>
+        <Checkbox onChange={e => setIsApiMocked(e.target.checked)}>Enable mocking</Checkbox>
       </Form.Item>
     </>
   );

--- a/src/components/ApiPublishModal/StepTitle.styled.tsx
+++ b/src/components/ApiPublishModal/StepTitle.styled.tsx
@@ -1,0 +1,16 @@
+import {ExclamationCircleOutlined as RawExclamationCircleOutlined} from '@ant-design/icons';
+
+import styled from 'styled-components';
+
+import Colors from '@styles/colors';
+
+export const ExclamationCircleOutlined = styled(RawExclamationCircleOutlined)`
+  color: ${Colors.yellow400};
+  cursor: pointer;
+`;
+
+export const StepTitleContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;

--- a/src/components/ApiPublishModal/StepTitle.tsx
+++ b/src/components/ApiPublishModal/StepTitle.tsx
@@ -1,0 +1,29 @@
+import {Tooltip} from 'antd';
+
+import {TOOLTIP_DELAY} from '@constants/constants';
+import {StepNotApplicableTooltip} from '@constants/tooltips';
+
+import * as S from './StepTitle.styled';
+
+interface IProps {
+  title: string;
+  isStepApplicable?: boolean;
+}
+
+const StepTitle: React.FC<IProps> = props => {
+  const {title, isStepApplicable = true} = props;
+
+  return (
+    <S.StepTitleContainer>
+      {title}
+
+      {!isStepApplicable && (
+        <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={StepNotApplicableTooltip}>
+          <S.ExclamationCircleOutlined />
+        </Tooltip>
+      )}
+    </S.StepTitleContainer>
+  );
+};
+
+export default StepTitle;

--- a/src/constants/tooltips.ts
+++ b/src/constants/tooltips.ts
@@ -1,2 +1,3 @@
 export const KuskExtensionTooltip = 'Contains kusk extension';
 export const EnvoyFleetInfoTooltip = 'Envoy fleet information';
+export const StepNotApplicableTooltip = 'Step not applicable as mocking is enabled!';

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -17,6 +17,8 @@ enum Colors {
   magenta1 = '#551C3B',
   magenta0 = '#291321',
 
+  yellow400 = '#FACC15',
+
   blackPure = '#000000',
   whitePure = '#ffffff',
 }


### PR DESCRIPTION
## Changes

- Shows steps that are not applicable when mocking is enabled ( with warning icon )

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/163806443-6bfba8df-e83d-4af9-9bda-b83b68de460d.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
