### PR TITLE
feat: remember active step of api publish wizard

### DIFF
--- a/src/components/ApiPublishModal/ApiPublishModal.tsx
+++ b/src/components/ApiPublishModal/ApiPublishModal.tsx
@@ -12,7 +12,7 @@ import {ApiContent} from '@models/main';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {setAlert} from '@redux/reducers/alert';
 import {setApis, setNewApiContent} from '@redux/reducers/main';
-import {closeApiPublishModal} from '@redux/reducers/ui';
+import {closeApiPublishModal, setApiPublishModalActiveStep} from '@redux/reducers/ui';
 
 import StepTitle from './StepTitle';
 
@@ -54,14 +54,13 @@ const orderedSteps = [
   'cors',
   'websocket',
 ] as const;
-type StepType = typeof orderedSteps[number];
 
 const ApiPublishModal: React.FC = () => {
   const dispatch = useAppDispatch();
+  const activeStep = useAppSelector(state => state.ui.apiPublishModal.activeStep);
   const apiContent = useAppSelector(state => state.main.newApiContent);
   const apis = useAppSelector(state => state.main.apis);
 
-  const [activeStep, setActiveStep] = useState<StepType>('openApiSpec');
   const [errorMessage, setErrorMessage] = useState<string>();
   const [isApiMocked, setIsApiMocked] = useState<boolean>(false);
   const [isPublishDisabled, setIsPublishedDisabled] = useState<boolean>(true);
@@ -223,7 +222,7 @@ const ApiPublishModal: React.FC = () => {
 
       if (!deploy && activeStep !== 'websocket') {
         dispatch(setNewApiContent(newApiContent));
-        setActiveStep(orderedSteps[orderedSteps.indexOf(activeStep) + 1]);
+        dispatch(setApiPublishModalActiveStep(orderedSteps[orderedSteps.indexOf(activeStep) + 1]));
       }
 
       if (deploy && newApiContent) {
@@ -243,6 +242,7 @@ const ApiPublishModal: React.FC = () => {
 
             dispatch(setApis([...apis, apiData]));
             dispatch(closeApiPublishModal());
+            dispatch(setApiPublishModalActiveStep('openApiSpec'));
             dispatch(setNewApiContent(null));
 
             dispatch(
@@ -261,7 +261,7 @@ const ApiPublishModal: React.FC = () => {
   };
 
   const onBackHandler = () => {
-    setActiveStep(orderedSteps[orderedSteps.indexOf(activeStep) - 1]);
+    dispatch(setApiPublishModalActiveStep(orderedSteps[orderedSteps.indexOf(activeStep) - 1]));
     setErrorMessage('');
   };
 
@@ -324,80 +324,29 @@ const ApiPublishModal: React.FC = () => {
             <S.Step
               title={
                 <StepTitle
+                  step="openApiSpec"
                   title="OpenAPI Spec"
-                  documentationLink="https://swagger.io/specification/"
-                  isStepActive={activeStep === 'openApiSpec'}
+                  documentationLink="https://swagger.io/specification"
                 />
               }
             />
-            <S.Step title={<StepTitle title="API Info" />} />
+            <S.Step title={<StepTitle step="apiInfo" title="API Info" />} />
+            <S.Step title={<StepTitle step="validation" title="Validation" isStepApplicable={!isApiMocked} />} />
             <S.Step
               title={
                 <StepTitle
-                  title="Validation"
-                  documentationLink="https://kubeshop.github.io/kusk-gateway/extension/#validation"
-                  isStepActive={activeStep === 'validation'}
-                  isStepApplicable={!isApiMocked}
-                />
-              }
-            />
-            <S.Step
-              title={
-                <StepTitle
+                  step="upstreamOrRedirect"
                   title="Upstream | Redirect"
                   documentationLink={`https://kubeshop.github.io/kusk-gateway/extension/#${upstreamRedirectTabSelection}`}
-                  isStepActive={activeStep === 'upstreamOrRedirect'}
                   isStepApplicable={!isApiMocked}
                 />
               }
             />
-            <S.Step
-              title={
-                <StepTitle
-                  title="Hosts"
-                  documentationLink="https://kubeshop.github.io/kusk-gateway/extension/#hosts"
-                  isStepActive={activeStep === 'hosts'}
-                />
-              }
-            />
-            <S.Step
-              title={
-                <StepTitle
-                  title="QOS"
-                  documentationLink="https://kubeshop.github.io/kusk-gateway/extension/#qos"
-                  isStepActive={activeStep === 'qos'}
-                  isStepApplicable={!isApiMocked}
-                />
-              }
-            />
-            <S.Step
-              title={
-                <StepTitle
-                  title="Path"
-                  documentationLink="https://kubeshop.github.io/kusk-gateway/extension/#path"
-                  isStepActive={activeStep === 'path'}
-                />
-              }
-            />
-            <S.Step
-              title={
-                <StepTitle
-                  title="CORS"
-                  documentationLink="https://kubeshop.github.io/kusk-gateway/extension/#cors"
-                  isStepActive={activeStep === 'cors'}
-                />
-              }
-            />
-            <S.Step
-              title={
-                <StepTitle
-                  title="Websocket"
-                  documentationLink="https://kubeshop.github.io/kusk-gateway/extension/#websocket"
-                  isStepActive={activeStep === 'websocket'}
-                  isStepApplicable={!isApiMocked}
-                />
-              }
-            />
+            <S.Step title={<StepTitle step="hosts" title="Hosts" />} />
+            <S.Step title={<StepTitle step="qos" title="QOS" isStepApplicable={!isApiMocked} />} />
+            <S.Step title={<StepTitle step="path" title="Path" />} />
+            <S.Step title={<StepTitle step="cors" title="CORS" />} />
+            <S.Step title={<StepTitle step="websocket" title="Websocket" isStepApplicable={!isApiMocked} />} />
           </Steps>
         </S.StepsContainer>
 

--- a/src/components/ApiPublishModal/StepTitle.tsx
+++ b/src/components/ApiPublishModal/StepTitle.tsx
@@ -3,19 +3,30 @@ import {Tooltip} from 'antd';
 import {TOOLTIP_DELAY} from '@constants/constants';
 import {StepNotApplicableTooltip} from '@constants/tooltips';
 
+import {StepType} from '@models/ui';
+
+import {useAppSelector} from '@redux/hooks';
+
 import ExternalLinkIcon from '@components/Icons/ExternalLink';
 
 import * as S from './StepTitle.styled';
 
 interface IProps {
+  step: StepType;
   title: string;
   documentationLink?: string;
-  isStepActive?: boolean;
   isStepApplicable?: boolean;
 }
 
 const StepTitle: React.FC<IProps> = props => {
-  const {title, documentationLink = '', isStepActive = false, isStepApplicable = true} = props;
+  const {
+    step,
+    title,
+    documentationLink = `https://kubeshop.github.io/kusk-gateway/extension/#${step}`,
+    isStepApplicable = true,
+  } = props;
+
+  const activeStep = useAppSelector(state => state.ui.apiPublishModal.activeStep);
 
   return (
     <>
@@ -29,7 +40,7 @@ const StepTitle: React.FC<IProps> = props => {
         )}
       </S.StepTitleContainer>
 
-      {documentationLink && isStepActive && (
+      {step !== 'apiInfo' && step === activeStep && (
         <S.LearnMoreContainer href={documentationLink} rel="noopener noreferrer" target="_blank">
           Learn more
           <ExternalLinkIcon height={15} width={15} />

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -1,8 +1,19 @@
 import {EnvoyFleetItem} from './api';
 import {ApiInfoTabs, EnvoyFleetInfoTabs, StaticRouteInfoTabs} from './dashboard';
 
+type StepType =
+  | 'openApiSpec'
+  | 'apiInfo'
+  | 'validation'
+  | 'upstreamOrRedirect'
+  | 'hosts'
+  | 'qos'
+  | 'path'
+  | 'cors'
+  | 'websocket';
 interface UiState {
   apiPublishModal: {
+    activeStep: StepType;
     isOpen: boolean;
   };
   apiInfoActiveTab: ApiInfoTabs;
@@ -26,4 +37,4 @@ interface DashboardPaneConfiguration {
   rightPaneWidth: number;
 }
 
-export type {DashboardPaneConfiguration, UiState};
+export type {DashboardPaneConfiguration, StepType, UiState};

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -20,6 +20,7 @@ const initialMainState: MainState = {
 
 const initialUiState: UiState = {
   apiPublishModal: {
+    activeStep: 'openApiSpec',
     isOpen: false,
   },
   apiInfoActiveTab: 'raw-api-spec',

--- a/src/redux/reducers/ui.ts
+++ b/src/redux/reducers/ui.ts
@@ -1,7 +1,7 @@
 import {Draft, PayloadAction, createSlice} from '@reduxjs/toolkit';
 
 import {ApiInfoTabs, EnvoyFleetInfoTabs, StaticRouteInfoTabs} from '@models/dashboard';
-import {DashboardPaneConfiguration, UiState} from '@models/ui';
+import {DashboardPaneConfiguration, StepType, UiState} from '@models/ui';
 
 import initialState from '@redux/initialState';
 
@@ -21,6 +21,10 @@ export const uiSlice = createSlice({
 
     setApiInfoActiveTab: (state: Draft<UiState>, action: PayloadAction<ApiInfoTabs>) => {
       state.apiInfoActiveTab = action.payload;
+    },
+
+    setApiPublishModalActiveStep: (state: Draft<UiState>, action: PayloadAction<StepType>) => {
+      state.apiPublishModal.activeStep = action.payload;
     },
 
     setDashboardPaneConfiguration: (state: Draft<UiState>, action: PayloadAction<DashboardPaneConfiguration>) => {
@@ -71,6 +75,7 @@ export const {
   closeApiPublishModal,
   openApiPublishModal,
   setApiInfoActiveTab,
+  setApiPublishModalActiveStep,
   setEnvoyFleetInfoActiveTab,
   setKuskExtensionsActiveKeys,
   setDashboardPaneConfiguration,


### PR DESCRIPTION
## Changes

- Remembers the active step of the API Publish modal until publishing the API

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
