### PR TITLE
refactor: api info tabs renaming

### DIFF
--- a/src/components/Apis/ApiInfo/ApiInfo.tsx
+++ b/src/components/Apis/ApiInfo/ApiInfo.tsx
@@ -12,9 +12,9 @@ import {ContentWrapper, InfoPaneCloseIcon, InfoPaneContainer} from '@components/
 import Colors from '@styles/colors';
 
 const TABS_ITEMS = [
-  {key: 'raw-api-spec', label: 'Raw API Spec'},
-  {key: 'post-processed-api-spec', label: 'Post-Processed API Spec'},
+  {key: 'api-definition', label: 'API Definition'},
   {key: 'kusk-extensions', label: 'Kusk Extensions'},
+  {key: 'public-api-definition', label: 'Public API Definition'},
 ];
 
 const KuskExtensions = lazy(() => import('@components/KuskExtensions/KuskExtensions'));
@@ -27,7 +27,7 @@ const ApiInfo: React.FC = () => {
 
   const onCloseHandler = () => {
     dispatch(selectApi(null));
-    dispatch(setApiInfoActiveTab('raw-api-spec'));
+    dispatch(setApiInfoActiveTab('api-definition'));
   };
 
   return (
@@ -36,9 +36,9 @@ const ApiInfo: React.FC = () => {
         <InfoTabs activeTabKey={activeTab} tabs={TABS_ITEMS} setActiveTab={setApiInfoActiveTab} />
 
         <Suspense fallback={<Skeleton />}>
-          {activeTab === 'raw-api-spec' && <RawApiSpec />}
-          {activeTab === 'post-processed-api-spec' && <PostProcessedApiSpec />}
+          {activeTab === 'api-definition' && <RawApiSpec />}
           {activeTab === 'kusk-extensions' && <KuskExtensions />}
+          {activeTab === 'public-api-definition' && <PostProcessedApiSpec />}
         </Suspense>
 
         <InfoPaneCloseIcon onClick={onCloseHandler} />

--- a/src/components/TableOfContents/TableOfContents.tsx
+++ b/src/components/TableOfContents/TableOfContents.tsx
@@ -46,11 +46,11 @@ const TableOfContents: React.FC<IProps> = props => {
   );
 
   const resizeTableOfContentsHandler = useCallback(() => {
-    if (apiInfoActiveTab === 'raw-api-spec') {
+    if (apiInfoActiveTab === 'api-definition') {
       dispatch(setRawApiSpecTableOfContentsHeight(height));
     }
 
-    if (apiInfoActiveTab === 'post-processed-api-spec') {
+    if (apiInfoActiveTab === 'public-api-definition') {
       dispatch(setPostProcessedTabledOfContentsHeight(height));
     }
   }, [apiInfoActiveTab, dispatch, height]);
@@ -58,7 +58,7 @@ const TableOfContents: React.FC<IProps> = props => {
   const tableOfContentsResizableHeight = useMemo(
     () =>
       height ||
-      (apiInfoActiveTab === 'raw-api-spec'
+      (apiInfoActiveTab === 'api-definition'
         ? tableOfContentsHeight.rawApiSpec
         : tableOfContentsHeight.postProcessedApiSpec),
     [apiInfoActiveTab, height, tableOfContentsHeight.postProcessedApiSpec, tableOfContentsHeight.rawApiSpec]

--- a/src/models/dashboard.ts
+++ b/src/models/dashboard.ts
@@ -6,6 +6,6 @@ export interface KuskExtensionsItem {
   tag?: string;
 }
 
-export type ApiInfoTabs = 'raw-api-spec' | 'post-processed-api-spec' | 'kusk-extensions';
+export type ApiInfoTabs = 'api-definition' | 'public-api-definition' | 'kusk-extensions';
 export type EnvoyFleetInfoTabs = 'crd' | 'apis' | 'static-routes';
 export type StaticRouteInfoTabs = 'crd';

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -23,7 +23,7 @@ const initialUiState: UiState = {
     activeStep: 'openApiSpec',
     isOpen: false,
   },
-  apiInfoActiveTab: 'raw-api-spec',
+  apiInfoActiveTab: 'api-definition',
   dashboardPaneConfiguration: {
     leftPaneWidth: 0.5,
     rightPaneWidth: 0.5,


### PR DESCRIPTION
## Changes

- "Raw API Spec" -> "API Definition"
- "Kusk Extensions" -> same name, move to second place
- "Post-processed API Spec" -> "Public API Definition"

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
