### PR TITLE
feat: mocking missing examples warning

### DIFF
--- a/src/components/ApiPublishModal/ApiPublishModal.tsx
+++ b/src/components/ApiPublishModal/ApiPublishModal.tsx
@@ -371,7 +371,7 @@ const ApiPublishModal: React.FC = () => {
           >
             <Suspense fallback={<Skeleton />}>
               {activeStep === 'openApiSpec' && (
-                <OpenApiSpec form={form} setIsApiMocked={value => setIsApiMocked(value)} />
+                <OpenApiSpec form={form} isApiMocked={isApiMocked} setIsApiMocked={value => setIsApiMocked(value)} />
               )}
               {activeStep === 'apiInfo' && <ApiInfo form={form} />}
               {activeStep === 'validation' && <Validation form={form} isApiMocked={isApiMocked} />}

--- a/src/components/ApiPublishModal/OpenApiSpec.styled.tsx
+++ b/src/components/ApiPublishModal/OpenApiSpec.styled.tsx
@@ -1,13 +1,24 @@
 import {Input} from 'antd';
 
+import {ExclamationCircleOutlined as RawExclamationCircleOutlined} from '@ant-design/icons';
+
 import styled from 'styled-components';
 
 import {GlobalScrollbarStyle} from '@utils/scrollbar';
 
 import Colors from '@styles/colors';
 
+export const ExclamationCircleOutlined = styled(RawExclamationCircleOutlined)`
+  margin-right: 10px;
+`;
+
 export const Textarea = styled(Input.TextArea)`
   background-color: ${Colors.grey2};
 
   ${GlobalScrollbarStyle}
+`;
+
+export const WarningsContainer = styled.div`
+  color: ${Colors.yellow500};
+  margin-bottom: 15px;
 `;

--- a/src/components/ApiPublishModal/OpenApiSpec.tsx
+++ b/src/components/ApiPublishModal/OpenApiSpec.tsx
@@ -104,12 +104,12 @@ const OpenApiSpec: React.FC<IProps> = props => {
 };
 
 const findResponseExample = (key: string, children: any, check: {hasExample: boolean}) => {
-  if ((key === 'example' && children) || (key === 'examples' && children.length)) {
+  if ((key === 'example' && children) || (key === 'examples' && children && Object.entries(children).length)) {
     check.hasExample = true;
     return;
   }
 
-  if (typeof children === 'object') {
+  if (children && typeof children === 'object') {
     Object.entries(children).forEach(([k, c]) => findResponseExample(k, c, check));
   }
 };

--- a/src/components/ApiPublishModal/OpenApiSpec.tsx
+++ b/src/components/ApiPublishModal/OpenApiSpec.tsx
@@ -122,7 +122,7 @@ const checkMockingExamples = (spec: {[key: string]: any}) => {
   Object.entries(paths).forEach((pathEntry: [string, any]) => {
     const [path, pathValue] = pathEntry;
 
-    const pathMocking = pathValue['x-kusk']?.mocking.enabled;
+    const pathMocking = pathValue['x-kusk']?.mocking?.enabled;
 
     if (pathMocking !== false) {
       Object.entries(pathValue)
@@ -130,7 +130,7 @@ const checkMockingExamples = (spec: {[key: string]: any}) => {
         .forEach((operationEntry: [string, any]) => {
           const [operation, operationValue] = operationEntry;
 
-          const operationMocking = operationValue['x-kusk']?.mocking.enabled;
+          const operationMocking = operationValue['x-kusk']?.mocking?.enabled;
           let missingExamplesCount = 0;
 
           if (operationMocking !== false) {

--- a/src/components/ApiPublishModal/OpenApiSpec.tsx
+++ b/src/components/ApiPublishModal/OpenApiSpec.tsx
@@ -117,11 +117,16 @@ const findResponseExample = (key: string, children: any, check: {hasExample: boo
 const checkMockingExamples = (spec: {[key: string]: any}) => {
   const paths = spec.paths;
 
+  if (!paths) {
+    return [];
+  }
+
   let warnings: string[] = [];
 
   Object.entries(paths).forEach((pathEntry: [string, any]) => {
     const [path, pathValue] = pathEntry;
 
+    // mocking kusk extension from path level
     const pathMocking = pathValue['x-kusk']?.mocking?.enabled;
 
     if (pathMocking !== false) {
@@ -130,6 +135,7 @@ const checkMockingExamples = (spec: {[key: string]: any}) => {
         .forEach((operationEntry: [string, any]) => {
           const [operation, operationValue] = operationEntry;
 
+          // mocking kusk extension from operation level
           const operationMocking = operationValue['x-kusk']?.mocking?.enabled;
           let missingExamplesCount = 0;
 

--- a/src/components/ApiPublishModal/OpenApiSpec.tsx
+++ b/src/components/ApiPublishModal/OpenApiSpec.tsx
@@ -122,30 +122,38 @@ const checkMockingExamples = (spec: {[key: string]: any}) => {
   Object.entries(paths).forEach((pathEntry: [string, any]) => {
     const [path, pathValue] = pathEntry;
 
-    Object.entries(pathValue)
-      .filter(entry => SUPPORTED_METHODS.includes(entry[0]))
-      .forEach((operationEntry: [string, any]) => {
-        const [operation, operationValue] = operationEntry;
-        let missingExamplesCount = 0;
+    const pathMocking = pathValue['x-kusk']?.mocking.enabled;
 
-        Object.entries(operationValue.responses).forEach((responseEntry: [string, any]) => {
-          const [responseCode, responseValue] = responseEntry;
+    if (pathMocking !== false) {
+      Object.entries(pathValue)
+        .filter(entry => SUPPORTED_METHODS.includes(entry[0]))
+        .forEach((operationEntry: [string, any]) => {
+          const [operation, operationValue] = operationEntry;
 
-          if (parseInt(responseCode, 10) < 300) {
-            let check = {hasExample: false};
+          const operationMocking = operationValue['x-kusk']?.mocking.enabled;
+          let missingExamplesCount = 0;
 
-            findResponseExample(responseCode, responseValue, check);
+          if (operationMocking !== false) {
+            Object.entries(operationValue.responses).forEach((responseEntry: [string, any]) => {
+              const [responseCode, responseValue] = responseEntry;
 
-            if (!check.hasExample) {
-              missingExamplesCount += 1;
-            }
+              if (parseInt(responseCode, 10) < 300) {
+                let check = {hasExample: false};
+
+                findResponseExample(responseCode, responseValue, check);
+
+                if (!check.hasExample) {
+                  missingExamplesCount += 1;
+                }
+              }
+            });
+          }
+
+          if (missingExamplesCount) {
+            warnings.push(`${path} -> ${operation} is missing mocking examples!`);
           }
         });
-
-        if (missingExamplesCount) {
-          warnings.push(`${path} -> ${operation} is missing mocking examples!`);
-        }
-      });
+    }
   });
 
   return warnings;

--- a/src/components/ApiPublishModal/OpenApiSpec.tsx
+++ b/src/components/ApiPublishModal/OpenApiSpec.tsx
@@ -1,8 +1,10 @@
-import {useEffect} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 
 import {Checkbox, Form, FormInstance} from 'antd';
 
 import YAML from 'yaml';
+
+import {SUPPORTED_METHODS} from '@constants/constants';
 
 import {useAppSelector} from '@redux/hooks';
 
@@ -10,13 +12,33 @@ import * as S from './OpenApiSpec.styled';
 
 interface IProps {
   form: FormInstance<any>;
+  isApiMocked: boolean;
   setIsApiMocked: (value: boolean) => void;
 }
 
 const OpenApiSpec: React.FC<IProps> = props => {
-  const {form, setIsApiMocked} = props;
+  const {form, isApiMocked, setIsApiMocked} = props;
 
   const apiContent = useAppSelector(state => state.main.newApiContent);
+
+  const [warnings, setWarnings] = useState<string[]>([]);
+
+  const renderedWarnings = useMemo(() => {
+    if (!isApiMocked || !warnings.length) {
+      return null;
+    }
+
+    return (
+      <S.WarningsContainer>
+        {warnings.map(warning => (
+          <div key={warning}>
+            <S.ExclamationCircleOutlined />
+            {warning}
+          </div>
+        ))}
+      </S.WarningsContainer>
+    );
+  }, [isApiMocked, warnings]);
 
   useEffect(() => {
     if (!apiContent) {
@@ -57,14 +79,76 @@ const OpenApiSpec: React.FC<IProps> = props => {
           },
         ]}
       >
-        <S.Textarea rows={15} placeholder="Enter OpenAPI Spec in YAML/JSON format" />
+        <S.Textarea
+          rows={15}
+          placeholder="Enter OpenAPI Spec in YAML/JSON format"
+          onChange={e => {
+            const spec = e.target.value;
+
+            if (!spec) {
+              setWarnings([]);
+            } else {
+              setWarnings(checkMockingExamples(YAML.parse(JSON.parse(JSON.stringify(spec)))));
+            }
+          }}
+        />
       </Form.Item>
+
+      {renderedWarnings}
 
       <Form.Item name={['mocking', 'enabled']} valuePropName="checked">
         <Checkbox onChange={e => setIsApiMocked(e.target.checked)}>Enable mocking</Checkbox>
       </Form.Item>
     </>
   );
+};
+
+const findResponseExample = (key: string, children: any, check: {hasExample: boolean}) => {
+  if ((key === 'example' && children) || (key === 'examples' && children.length)) {
+    check.hasExample = true;
+    return;
+  }
+
+  if (typeof children === 'object') {
+    Object.entries(children).forEach(([k, c]) => findResponseExample(k, c, check));
+  }
+};
+
+const checkMockingExamples = (spec: {[key: string]: any}) => {
+  const paths = spec.paths;
+
+  let warnings: string[] = [];
+
+  Object.entries(paths).forEach((pathEntry: [string, any]) => {
+    const [path, pathValue] = pathEntry;
+
+    Object.entries(pathValue)
+      .filter(entry => SUPPORTED_METHODS.includes(entry[0]))
+      .forEach((operationEntry: [string, any]) => {
+        const [operation, operationValue] = operationEntry;
+        let missingExamplesCount = 0;
+
+        Object.entries(operationValue.responses).forEach((responseEntry: [string, any]) => {
+          const [responseCode, responseValue] = responseEntry;
+
+          if (parseInt(responseCode, 10) < 300) {
+            let check = {hasExample: false};
+
+            findResponseExample(responseCode, responseValue, check);
+
+            if (!check.hasExample) {
+              missingExamplesCount += 1;
+            }
+          }
+        });
+
+        if (missingExamplesCount) {
+          warnings.push(`${path} -> ${operation} is missing mocking examples!`);
+        }
+      });
+  });
+
+  return warnings;
 };
 
 export default OpenApiSpec;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -18,6 +18,7 @@ enum Colors {
   magenta0 = '#291321',
 
   yellow400 = '#FACC15',
+  yellow500 = '#EAB308',
 
   blue700 = '#1D4ED8',
   blue600 = '#2563EB',


### PR DESCRIPTION
## Changes

- Shows warning to the user of the `path -> operation` which are missing mocking examples ( if mocking is enabled )
    - Show warning based on kusk mocking extension from top/path/operation level

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/165308177-62089a87-bac2-4b58-a9b7-60a4ecd3f115.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
