### PR TITLE
feat: clickable wizard step

### DIFF
--- a/src/components/ApiPublishModal/ApiPublishModal.tsx
+++ b/src/components/ApiPublishModal/ApiPublishModal.tsx
@@ -350,6 +350,15 @@ const ApiPublishModal: React.FC = () => {
         <S.StepsContainer>
           <Steps direction="vertical" current={activeStepIndex}>
             <S.Step
+              $completed={
+                activeStep !== 'openApiSpec' &&
+                orderedSteps.indexOf('openApiSpec') <= orderedSteps.indexOf(lastCompletedStep)
+              }
+              onClick={() => {
+                if (activeStep !== 'openApiSpec') {
+                  dispatch(setApiPublishModalActiveStep('openApiSpec'));
+                }
+              }}
               status={setStepStatus('openApiSpec')}
               title={
                 <StepTitle
@@ -359,8 +368,25 @@ const ApiPublishModal: React.FC = () => {
                 />
               }
             />
-            <S.Step status={setStepStatus('apiInfo')} title={<StepTitle step="apiInfo" title="API Info" />} />
             <S.Step
+              $completed={
+                activeStep !== 'apiInfo' && orderedSteps.indexOf('apiInfo') <= orderedSteps.indexOf(lastCompletedStep)
+              }
+              status={setStepStatus('apiInfo')}
+              title={<StepTitle step="apiInfo" title="API Info" />}
+              onClick={() => {
+                if (
+                  activeStep !== 'apiInfo' &&
+                  orderedSteps.indexOf('apiInfo') <= orderedSteps.indexOf(lastCompletedStep)
+                ) {
+                  dispatch(setApiPublishModalActiveStep('apiInfo'));
+                }
+              }}
+            />
+            <S.Step
+              $completed={
+                activeStep !== 'target' && orderedSteps.indexOf('target') <= orderedSteps.indexOf(lastCompletedStep)
+              }
               status={setStepStatus('target')}
               title={
                 <StepTitle
@@ -370,21 +396,97 @@ const ApiPublishModal: React.FC = () => {
                   isStepApplicable={!isApiMocked}
                 />
               }
+              onClick={() => {
+                if (
+                  activeStep !== 'target' &&
+                  orderedSteps.indexOf('target') <= orderedSteps.indexOf(lastCompletedStep)
+                ) {
+                  dispatch(setApiPublishModalActiveStep('target'));
+                }
+              }}
             />
             <S.Step
+              $completed={
+                activeStep !== 'validation' &&
+                orderedSteps.indexOf('validation') <= orderedSteps.indexOf(lastCompletedStep)
+              }
               status={setStepStatus('validation')}
               title={<StepTitle step="validation" title="Validation" isStepApplicable={!isApiMocked} />}
+              onClick={() => {
+                if (
+                  activeStep !== 'validation' &&
+                  orderedSteps.indexOf('validation') <= orderedSteps.indexOf(lastCompletedStep)
+                ) {
+                  dispatch(setApiPublishModalActiveStep('validation'));
+                }
+              }}
             />
-            <S.Step status={setStepStatus('hosts')} title={<StepTitle step="hosts" title="Hosts" />} />
             <S.Step
+              $completed={
+                activeStep !== 'hosts' && orderedSteps.indexOf('hosts') <= orderedSteps.indexOf(lastCompletedStep)
+              }
+              status={setStepStatus('hosts')}
+              title={<StepTitle step="hosts" title="Hosts" />}
+              onClick={() => {
+                if (
+                  activeStep !== 'hosts' &&
+                  orderedSteps.indexOf('hosts') <= orderedSteps.indexOf(lastCompletedStep)
+                ) {
+                  dispatch(setApiPublishModalActiveStep('hosts'));
+                }
+              }}
+            />
+            <S.Step
+              $completed={
+                activeStep !== 'qos' && orderedSteps.indexOf('qos') <= orderedSteps.indexOf(lastCompletedStep)
+              }
               status={setStepStatus('qos')}
               title={<StepTitle step="qos" title="QOS" isStepApplicable={!isApiMocked} />}
+              onClick={() => {
+                if (activeStep !== 'qos' && orderedSteps.indexOf('qos') <= orderedSteps.indexOf(lastCompletedStep)) {
+                  dispatch(setApiPublishModalActiveStep('qos'));
+                }
+              }}
             />
-            <S.Step status={setStepStatus('path')} title={<StepTitle step="path" title="Path" />} />
-            <S.Step status={setStepStatus('cors')} title={<StepTitle step="cors" title="CORS" />} />
             <S.Step
+              $completed={
+                activeStep !== 'path' && orderedSteps.indexOf('path') <= orderedSteps.indexOf(lastCompletedStep)
+              }
+              status={setStepStatus('path')}
+              title={<StepTitle step="path" title="Path" />}
+              onClick={() => {
+                if (activeStep !== 'path' && orderedSteps.indexOf('path') <= orderedSteps.indexOf(lastCompletedStep)) {
+                  dispatch(setApiPublishModalActiveStep('path'));
+                }
+              }}
+            />
+            <S.Step
+              $completed={
+                activeStep !== 'cors' && orderedSteps.indexOf('cors') < orderedSteps.indexOf(lastCompletedStep)
+              }
+              status={setStepStatus('cors')}
+              title={<StepTitle step="cors" title="CORS" />}
+              onClick={() => {
+                if (activeStep !== 'cors' && orderedSteps.indexOf('cors') <= orderedSteps.indexOf(lastCompletedStep)) {
+                  dispatch(setApiPublishModalActiveStep('cors'));
+                }
+              }}
+            />
+            <S.Step
+              $completed={
+                activeStep !== 'websocket' &&
+                orderedSteps.indexOf('websocket') < orderedSteps.indexOf(lastCompletedStep)
+              }
               status={setStepStatus('websocket')}
               title={<StepTitle step="websocket" title="Websocket" isStepApplicable={!isApiMocked} />}
+              onClick={() => {
+                if (
+                  activeStep !== 'websocket' &&
+                  orderedSteps.indexOf('websocket') <= orderedSteps.indexOf(lastCompletedStep)
+                ) {
+                  dispatch(setApiPublishModalActiveStep('websocket'));
+                }
+              }}
             />
           </Steps>
         </S.StepsContainer>

--- a/src/components/ApiPublishModal/ApiPublishModal.tsx
+++ b/src/components/ApiPublishModal/ApiPublishModal.tsx
@@ -12,7 +12,11 @@ import {ApiContent} from '@models/main';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {setAlert} from '@redux/reducers/alert';
 import {setApis, setNewApiContent} from '@redux/reducers/main';
-import {closeApiPublishModal, setApiPublishModalActiveStep} from '@redux/reducers/ui';
+import {
+  closeApiPublishModal,
+  setApiPublishModalActiveStep,
+  setApiPublishModalLastCompletedStep,
+} from '@redux/reducers/ui';
 
 import StepTitle from './StepTitle';
 
@@ -58,6 +62,9 @@ const ApiPublishModal: React.FC = () => {
   const activeStep = useAppSelector(state => state.ui.apiPublishModal.activeStep);
   const apiContent = useAppSelector(state => state.main.newApiContent);
   const apis = useAppSelector(state => state.main.apis);
+  const lastCompletedStep = useAppSelector(state => state.ui.apiPublishModal.lastCompletedStep);
+
+  console.log(lastCompletedStep);
 
   const [errorMessage, setErrorMessage] = useState<string>();
   const [isApiMocked, setIsApiMocked] = useState<boolean>(false);
@@ -226,6 +233,7 @@ const ApiPublishModal: React.FC = () => {
       if (!publish && activeStep !== 'websocket') {
         dispatch(setNewApiContent(newApiContent));
         dispatch(setApiPublishModalActiveStep(orderedSteps[orderedSteps.indexOf(activeStep) + 1]));
+        dispatch(setApiPublishModalLastCompletedStep(activeStep));
       }
 
       if (publish && newApiContent) {

--- a/src/components/ApiPublishModal/Step.styled.tsx
+++ b/src/components/ApiPublishModal/Step.styled.tsx
@@ -1,0 +1,37 @@
+import {Steps} from 'antd';
+
+import styled from 'styled-components';
+
+export const Step = styled(Steps.Step)<{$completed: boolean}>`
+  ${({$completed}) => {
+    if ($completed) {
+      return `
+        & .ant-steps-item-container:hover {
+          cursor: pointer;
+
+          & .ant-steps-item-title {
+            font-weight: bold;
+          }
+        }
+      `;
+    }
+  }}
+
+  & .ant-steps-item-container {
+    width: max-content;
+  }
+
+  & .ant-steps-icon {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  & .ant-steps-item-title {
+    width: 100%;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+`;

--- a/src/components/ApiPublishModal/Step.tsx
+++ b/src/components/ApiPublishModal/Step.tsx
@@ -17,8 +17,14 @@ interface IProps {
 }
 
 const Step: React.FC<IProps> = props => {
-  const {isApiMocked, orderedSteps, step, title} = props;
-  const {documentationLink = `https://kubeshop.github.io/kusk-gateway/extension/#${step}`} = props;
+  const {
+    isApiMocked,
+    orderedSteps,
+    step,
+    title,
+    documentationLink = `https://kubeshop.github.io/kusk-gateway/extension/#${step}`,
+    ...rest
+  } = props;
 
   const dispatch = useAppDispatch();
   const activeStep = useAppSelector(state => state.ui.apiPublishModal.activeStep);
@@ -47,7 +53,7 @@ const Step: React.FC<IProps> = props => {
 
   return (
     <S.Step
-      {...props}
+      {...rest}
       $completed={isStepCompleted}
       status={stepStatus}
       title={

--- a/src/components/ApiPublishModal/Step.tsx
+++ b/src/components/ApiPublishModal/Step.tsx
@@ -1,0 +1,61 @@
+import {useMemo} from 'react';
+
+import {StepType} from '@models/ui';
+
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
+import {setApiPublishModalActiveStep} from '@redux/reducers/ui';
+
+import * as S from './Step.styled';
+import StepTitle from './StepTitle';
+
+interface IProps {
+  isApiMocked: boolean;
+  orderedSteps: StepType[];
+  step: StepType;
+  title: string;
+  documentationLink?: string;
+}
+
+const Step: React.FC<IProps> = props => {
+  const {isApiMocked, orderedSteps, step, title} = props;
+  const {documentationLink = `https://kubeshop.github.io/kusk-gateway/extension/#${step}`} = props;
+
+  const dispatch = useAppDispatch();
+  const activeStep = useAppSelector(state => state.ui.apiPublishModal.activeStep);
+  const lastCompletedStep = useAppSelector(state => state.ui.apiPublishModal.lastCompletedStep);
+
+  const isStepCompleted = useMemo(
+    () => activeStep !== step && orderedSteps.indexOf(step) <= orderedSteps.indexOf(lastCompletedStep),
+    [activeStep, lastCompletedStep, orderedSteps, step]
+  );
+
+  const stepStatus = useMemo(
+    () =>
+      activeStep === step
+        ? 'process'
+        : orderedSteps.indexOf(lastCompletedStep) < orderedSteps.indexOf(step)
+        ? 'wait'
+        : 'finish',
+    [activeStep, lastCompletedStep, orderedSteps, step]
+  );
+
+  const onClickHandler = () => {
+    if (activeStep !== step && orderedSteps.indexOf(step) <= orderedSteps.indexOf(lastCompletedStep)) {
+      dispatch(setApiPublishModalActiveStep(step));
+    }
+  };
+
+  return (
+    <S.Step
+      {...props}
+      $completed={isStepCompleted}
+      status={stepStatus}
+      title={
+        <StepTitle documentationLink={documentationLink} step={step} title={title} isStepApplicable={!isApiMocked} />
+      }
+      onClick={onClickHandler}
+    />
+  );
+};
+
+export default Step;

--- a/src/components/ApiPublishModal/StepTitle.tsx
+++ b/src/components/ApiPublishModal/StepTitle.tsx
@@ -12,19 +12,16 @@ import ExternalLinkIcon from '@components/Icons/ExternalLink';
 import * as S from './StepTitle.styled';
 
 interface IProps {
+  documentationLink: string;
   step: StepType;
   title: string;
-  documentationLink?: string;
   isStepApplicable?: boolean;
 }
 
+const mockingNotApplicableSteps = ['target', 'validation', 'qos', 'websocket'];
+
 const StepTitle: React.FC<IProps> = props => {
-  const {
-    step,
-    title,
-    documentationLink = `https://kubeshop.github.io/kusk-gateway/extension/#${step}`,
-    isStepApplicable = true,
-  } = props;
+  const {step, title, documentationLink, isStepApplicable = true} = props;
 
   const activeStep = useAppSelector(state => state.ui.apiPublishModal.activeStep);
 
@@ -33,7 +30,7 @@ const StepTitle: React.FC<IProps> = props => {
       <S.StepTitleContainer>
         {title}
 
-        {!isStepApplicable && (
+        {!isStepApplicable && mockingNotApplicableSteps.includes(step) && (
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={StepNotApplicableTooltip}>
             <S.ExclamationCircleOutlined />
           </Tooltip>

--- a/src/components/ApiPublishModal/styled.tsx
+++ b/src/components/ApiPublishModal/styled.tsx
@@ -1,4 +1,4 @@
-import {Alert as RawAlert, Steps} from 'antd';
+import {Alert as RawAlert} from 'antd';
 
 import styled from 'styled-components';
 
@@ -37,40 +37,6 @@ export const Label = styled.div`
 
 export const RadioGroupContainer = styled.div`
   margin-bottom: 15px;
-`;
-
-export const Step = styled(Steps.Step)<{$completed: boolean}>`
-  ${({$completed}) => {
-    if ($completed) {
-      return `
-        & .ant-steps-item-container:hover {
-          cursor: pointer;
-
-          & .ant-steps-item-title {
-            font-weight: bold;
-          }
-        }
-      `;
-    }
-  }}
-
-  & .ant-steps-item-container {
-    width: max-content;
-  }
-
-  & .ant-steps-icon {
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  & .ant-steps-item-title {
-    width: 100%;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-  }
 `;
 
 export const StepsContainer = styled.div`

--- a/src/components/ApiPublishModal/styled.tsx
+++ b/src/components/ApiPublishModal/styled.tsx
@@ -39,7 +39,25 @@ export const RadioGroupContainer = styled.div`
   margin-bottom: 15px;
 `;
 
-export const Step = styled(Steps.Step)`
+export const Step = styled(Steps.Step)<{$completed: boolean}>`
+  ${({$completed}) => {
+    if ($completed) {
+      return `
+        & .ant-steps-item-container:hover {
+          cursor: pointer;
+
+          & .ant-steps-item-title {
+            font-weight: bold;
+          }
+        }
+      `;
+    }
+  }}
+
+  & .ant-steps-item-container {
+    width: max-content;
+  }
+
   & .ant-steps-icon {
     height: 100%;
     display: flex;

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -5,6 +5,7 @@ interface UiState {
   apiPublishModal: {
     activeStep: StepType;
     isOpen: boolean;
+    lastCompletedStep: StepType;
   };
   apiInfoActiveTab: ApiInfoTabs;
   dashboardPaneConfiguration: DashboardPaneConfiguration;

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -22,6 +22,7 @@ const initialUiState: UiState = {
   apiPublishModal: {
     activeStep: 'openApiSpec',
     isOpen: false,
+    lastCompletedStep: 'openApiSpec',
   },
   apiInfoActiveTab: 'api-definition',
   dashboardPaneConfiguration: {

--- a/src/redux/reducers/ui.ts
+++ b/src/redux/reducers/ui.ts
@@ -27,6 +27,10 @@ export const uiSlice = createSlice({
       state.apiPublishModal.activeStep = action.payload;
     },
 
+    setApiPublishModalLastCompletedStep: (state: Draft<UiState>, action: PayloadAction<StepType>) => {
+      state.apiPublishModal.lastCompletedStep = action.payload;
+    },
+
     setDashboardPaneConfiguration: (state: Draft<UiState>, action: PayloadAction<DashboardPaneConfiguration>) => {
       state.dashboardPaneConfiguration = action.payload;
     },
@@ -69,6 +73,7 @@ export const {
   openApiPublishModal,
   setApiInfoActiveTab,
   setApiPublishModalActiveStep,
+  setApiPublishModalLastCompletedStep,
   setEnvoyFleetInfoActiveTab,
   setKuskExtensionsActiveKeys,
   setDashboardPaneConfiguration,


### PR DESCRIPTION
## Changes

- Make completed steps clickable that will jump you to that specific step
- If multiple steps are completed and the user jumps back to `openApiSpec` step and changes mocking, last completed step will be the `openApiSpec`

## Screenshot

![image](https://user-images.githubusercontent.com/47887589/165558266-d69b35bb-fcdb-452b-97df-29ea46a92957.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
