### PR TITLE
refactor: redirect dropdowns

### DIFF
--- a/src/components/ApiPublishModal/ApiInfo.tsx
+++ b/src/components/ApiPublishModal/ApiInfo.tsx
@@ -52,12 +52,12 @@ const ApiInfo: React.FC<IProps> = props => {
           },
         ]}
       >
-        <S.Input placeholder="Enter API name" type="text" />
+        <S.Input placeholder="API name" type="text" />
       </Form.Item>
 
       <Form.Item label="Namespace" name="namespace">
         <S.Input
-          placeholder="Enter API namespace"
+          placeholder="API namespace"
           type="text"
           onChange={() => {
             if (form.getFieldValue('name')) {

--- a/src/components/ApiPublishModal/OpenApiSpec.tsx
+++ b/src/components/ApiPublishModal/OpenApiSpec.tsx
@@ -88,7 +88,7 @@ const OpenApiSpec: React.FC<IProps> = props => {
       >
         <S.Textarea
           rows={15}
-          placeholder="Enter OpenAPI Spec in YAML/JSON format"
+          placeholder="OpenAPI Spec in YAML/JSON format"
           onChange={e => {
             const spec = e.target.value;
 

--- a/src/components/ApiPublishModal/extensions/Path.tsx
+++ b/src/components/ApiPublishModal/extensions/Path.tsx
@@ -29,7 +29,7 @@ const Path: React.FC<IProps> = props => {
 
   return (
     <Form.Item label="Prefix" name={['path', 'prefix']}>
-      <S.Input />
+      <S.Input placeholder="Prefix for the route" />
     </Form.Item>
   );
 };

--- a/src/components/ApiPublishModal/extensions/QOS.tsx
+++ b/src/components/ApiPublishModal/extensions/QOS.tsx
@@ -30,15 +30,15 @@ const QOS: React.FC<IProps> = props => {
   return (
     <>
       <Form.Item label="Idle timeout" name={['qos', 'idle_timeout']}>
-        <S.Input type="number" />
+        <S.Input placeholder="Timeout for idle connections" type="number" />
       </Form.Item>
 
       <Form.Item label="Retries" name={['qos', 'retries']}>
-        <S.Input type="number" />
+        <S.Input placeholder="Number of retries" type="number" />
       </Form.Item>
 
       <Form.Item label="Request timeout" name={['qos', 'request_timeout']}>
-        <S.Input type="number" />
+        <S.Input placeholder="Total request timeout" type="number" />
       </Form.Item>
     </>
   );

--- a/src/components/ApiPublishModal/extensions/Redirect.tsx
+++ b/src/components/ApiPublishModal/extensions/Redirect.tsx
@@ -6,6 +6,8 @@ import {useAppSelector} from '@redux/hooks';
 
 import * as S from './styled';
 
+const {Option} = S.Select;
+
 interface IProps {
   form: FormInstance<any>;
   selectedTab: string;
@@ -50,7 +52,10 @@ const Redirect: React.FC<IProps> = props => {
   return (
     <>
       <Form.Item label="Scheme redirect" name={['redirect', 'scheme_redirect']}>
-        <S.Input placeholder="http / https" />
+        <S.Select allowClear placeholder="Select redirect scheme">
+          <Option value="http">http</Option>
+          <Option value="https">https</Option>
+        </S.Select>
       </Form.Item>
 
       <Form.Item
@@ -80,7 +85,13 @@ const Redirect: React.FC<IProps> = props => {
       </Form.Item>
 
       <Form.Item label="Response code" name={['redirect', 'response_code']}>
-        <S.Input placeholder="Redirect response code" type="number" />
+        <S.Select allowClear placeholder="Select redirect response code">
+          <Option value="301">301</Option>
+          <Option value="302">302</Option>
+          <Option value="303">303</Option>
+          <Option value="307">307</Option>
+          <Option value="308">308</Option>
+        </S.Select>
       </Form.Item>
 
       <S.RadioGroup value={selectedTab} onChange={e => setSelectedTab(e.target.value)}>

--- a/src/components/ApiPublishModal/extensions/Redirect.tsx
+++ b/src/components/ApiPublishModal/extensions/Redirect.tsx
@@ -50,7 +50,7 @@ const Redirect: React.FC<IProps> = props => {
   return (
     <>
       <Form.Item label="Scheme redirect" name={['redirect', 'scheme_redirect']}>
-        <S.Input />
+        <S.Input placeholder="http / https" />
       </Form.Item>
 
       <Form.Item
@@ -63,7 +63,7 @@ const Redirect: React.FC<IProps> = props => {
           },
         ]}
       >
-        <S.Input />
+        <S.Input placeholder="Host to which requests should be redirected" />
       </Form.Item>
 
       <Form.Item
@@ -76,11 +76,11 @@ const Redirect: React.FC<IProps> = props => {
           },
         ]}
       >
-        <S.Input type="number" />
+        <S.Input placeholder="Port to which requests should be redirected" type="number" />
       </Form.Item>
 
       <Form.Item label="Response code" name={['redirect', 'response_code']}>
-        <S.Input type="number" />
+        <S.Input placeholder="Redirect response code" type="number" />
       </Form.Item>
 
       <S.RadioGroup value={selectedTab} onChange={e => setSelectedTab(e.target.value)}>
@@ -90,15 +90,15 @@ const Redirect: React.FC<IProps> = props => {
 
       {selectedTab === 'path_redirect' ? (
         <Form.Item name={['redirect', 'path_redirect']}>
-          <S.Input placeholder="Enter path redirect" />
+          <S.Input placeholder="Path to which requests should be redirected" />
         </Form.Item>
       ) : (
         <>
           <Form.Item label="Pattern" name={['redirect', 'rewrite_regex', 'pattern']}>
-            <S.Input />
+            <S.Input placeholder="Regex pattern that should be rewritten" />
           </Form.Item>
           <Form.Item label="Substitution" name={['redirect', 'rewrite_regex', 'substitution']}>
-            <S.Input />
+            <S.Input placeholder="Substitution for specified regex pattern" />
           </Form.Item>
         </>
       )}

--- a/src/components/ApiPublishModal/extensions/Upstream.tsx
+++ b/src/components/ApiPublishModal/extensions/Upstream.tsx
@@ -159,7 +159,7 @@ const Upstream: React.FC<IProps> = props => {
               },
             ]}
           >
-            <S.Input disabled={Boolean(selectedService)} />
+            <S.Input disabled={Boolean(selectedService)} placeholder="Name of the target Service in your cluster" />
           </Form.Item>
 
           <Form.Item
@@ -172,7 +172,10 @@ const Upstream: React.FC<IProps> = props => {
               },
             ]}
           >
-            <S.Input disabled={Boolean(selectedService)} />
+            <S.Input
+              disabled={Boolean(selectedService)}
+              placeholder="Namespace of the target Service in your cluster"
+            />
           </Form.Item>
 
           <Form.Item
@@ -186,7 +189,7 @@ const Upstream: React.FC<IProps> = props => {
             ]}
           >
             {selectedService ? (
-              <S.Select placeholder="Select port">
+              <S.Select placeholder="Target port to which requests should be routed">
                 {selectedServicePorts.map(port => (
                   <Option key={port} value={port}>
                     {port}
@@ -194,7 +197,7 @@ const Upstream: React.FC<IProps> = props => {
                 ))}
               </S.Select>
             ) : (
-              <S.Input type="number" />
+              <S.Input type="number" placeholder="Target port to which requests should be routed" />
             )}
           </Form.Item>
         </>
@@ -222,18 +225,18 @@ const Upstream: React.FC<IProps> = props => {
               },
             ]}
           >
-            <S.Input type="number" />
+            <S.Input placeholder="Target port to which requests should be routed" type="number" />
           </Form.Item>
         </>
       )}
 
       <S.ExtensionSubHeading>Rewrite</S.ExtensionSubHeading>
       <Form.Item label="Pattern" name={['upstream', 'rewrite', 'rewrite_regex', 'pattern']}>
-        <S.Input />
+        <S.Input placeholder="Regex pattern that should be rewritten" />
       </Form.Item>
 
       <Form.Item label="Substitution" name={['upstream', 'rewrite', 'rewrite_regex', 'substitution']}>
-        <S.Input />
+        <S.Input placeholder="Substitution for specified regex pattern" />
       </Form.Item>
     </>
   );

--- a/src/components/ApiPublishModal/extensions/Upstream.tsx
+++ b/src/components/ApiPublishModal/extensions/Upstream.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useMemo, useState} from 'react';
 
-import {Form, FormInstance, Radio, Select, Skeleton, Tag} from 'antd';
+import {Form, FormInstance, Radio, Skeleton, Tag} from 'antd';
 
 import {ServiceItem} from '@models/api';
 
@@ -10,7 +10,7 @@ import {ErrorLabel} from '@components/AntdCustom';
 
 import * as S from './styled';
 
-const {Option} = Select;
+const {Option} = S.Select;
 
 interface IProps {
   form: FormInstance<any>;


### PR DESCRIPTION
## Changes

- Make redirect scheme a dropdown ( `http` and `https` as options )
- Make redirect response code a dropdown ( `301`, `302`, `303`, `307` and `308` as options )

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/166223784-af8b47da-31f6-4d01-abf1-776bb8aeddbc.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
